### PR TITLE
Respect cluster_node_is_arbiter while installing packages

### DIFF
--- a/tasks/debian10.yml
+++ b/tasks/debian10.yml
@@ -6,10 +6,10 @@
   loop:
     - "{{ pacemaker_cluster_package }}"
     - "{{ pcs_module_dependencies }}"
+  when: not cluster_node_is_arbiter
 
 - name: Install required package on the qdevice
   apt:
-    name: "{{ item }}"
+    name: "{{ pacemaker_qdevice_package }}"
     state: 'present'
-  loop:
-    - "{{ pacemaker_qdevice_package }}"
+  when: cluster_node_is_arbiter


### PR DESCRIPTION
While there fixed a common ansible-lint complain: no loop with the apt module.